### PR TITLE
add: basic docker-compose dev enviroment for keycloak and discourse

### DIFF
--- a/docker/.gitignore
+++ b/docker/.gitignore
@@ -1,0 +1,2 @@
+discourse_db_data/
+discourse/

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,43 @@
+# KeyCloak and Discourse Docker dev environment
+* KeyCloak URL: http://localhost:8080
+* Discourse URL: http://localhost:3000
+
+### 1. Clone Discourse 
+```bash
+$ git clone https://github.com/discourse/discourse.git
+```
+
+Modify `discourse/config/database.yml` to add `username: discourse` to the development database connection configuration:
+
+```yml
+development:
+  prepared_statements: false
+  username: discourse
+  ...
+```
+
+### 2. Start the containers
+```bash
+$ docker-compose up
+```
+
+### 3. Set-up Discourse
+```bash
+$ docker-compose exec -w /src discourse bundle install
+$ docker-compose exec -w /src discourse yarn install
+$ docker-compose exec -w /src discourse rake db:migrate
+$ docker-compose exec -w /src discourse rake admin:create
+Email:
+...
+```
+Complete the email and password and set the user to be an admin.
+
+### 4. Start Discourse server
+```bash
+$ docker-compose exec -w /src discourse rails server
+I, [2024-01-25T14:25:22.938512 #5719]  INFO -- : Refreshing Gem list
+Starting CSS change watcher
+I, [2024-01-25T14:25:25.889439 #5719]  INFO -- : listening on addr=0.0.0.0:3000 fd=24
+...
+```
+

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,50 @@
+version: '3'
+
+services:
+  keycloak:
+    image: quay.io/keycloak/keycloak:latest
+    environment:
+      KEYCLOAK_ADMIN: admin
+      KEYCLOAK_ADMIN_PASSWORD: admin
+      DB_VENDOR: POSTGRES
+      DB_ADDR: keycloak_db
+      DB_DATABASE: keycloak
+      DB_USER: postgres
+      DB_PASSWORD: postgres
+      KEYCLOAK_LOGLEVEL: DEBUG
+    entrypoint: "/opt/keycloak/bin/kc.sh start-dev"
+    ports:
+      - "8080:8080"
+    depends_on:
+      - keycloak_db
+
+  keycloak_db:
+    image: postgres:latest
+    environment:
+      POSTGRES_DB: keycloak
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - "5432:5432"
+
+  discourse:
+    image: discourse/discourse_dev:release
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./discourse:/src:delegated
+      - ./discourse_db_data:/shared/postgres_data:delegated"
+      - ./pg_hba.conf:/etc/postgresql/13/main/pg_hba.conf:delegated
+    entrypoint: "/sbin/boot --init"
+    environment:
+      DISCOURSE_HOSTNAME: 'localhost'
+      UNICORN_BIND_ALL: 1
+      ALLOW_EMBER_CLI_PROXY_BYPASS: 1
+      DISCOURSE_DEV_DB: discourse
+    #   DISCOURSE_DEVELOPER_EMAILS: 'your-email@example.com'
+    #   DISCOURSE_SMTP_ADDRESS: 'smtp.example.com'
+    #   DISCOURSE_SMTP_PORT: 587
+    #   DISCOURSE_SMTP_USER_NAME: 'your-smtp-username'
+    #   DISCOURSE_SMTP_PASSWORD: 'your-smtp-password'
+    #   LETSENCRYPT_ACCOUNT_EMAIL: 'your-email@example.com'
+    restart: always

--- a/docker/pg_hba.conf
+++ b/docker/pg_hba.conf
@@ -1,0 +1,104 @@
+# PostgreSQL Client Authentication Configuration File
+# ===================================================
+#
+# Refer to the "Client Authentication" section in the PostgreSQL
+# documentation for a complete description of this file.  A short
+# synopsis follows.
+#
+# This file controls: which hosts are allowed to connect, how clients
+# are authenticated, which PostgreSQL user names they can use, which
+# databases they can access.  Records take one of these forms:
+#
+# local         DATABASE  USER  METHOD  [OPTIONS]
+# host          DATABASE  USER  ADDRESS  METHOD  [OPTIONS]
+# hostssl       DATABASE  USER  ADDRESS  METHOD  [OPTIONS]
+# hostnossl     DATABASE  USER  ADDRESS  METHOD  [OPTIONS]
+# hostgssenc    DATABASE  USER  ADDRESS  METHOD  [OPTIONS]
+# hostnogssenc  DATABASE  USER  ADDRESS  METHOD  [OPTIONS]
+#
+# (The uppercase items must be replaced by actual values.)
+#
+# The first field is the connection type: "local" is a Unix-domain
+# socket, "host" is either a plain or SSL-encrypted TCP/IP socket,
+# "hostssl" is an SSL-encrypted TCP/IP socket, and "hostnossl" is a
+# non-SSL TCP/IP socket.  Similarly, "hostgssenc" uses a
+# GSSAPI-encrypted TCP/IP socket, while "hostnogssenc" uses a
+# non-GSSAPI socket.
+#
+# DATABASE can be "all", "sameuser", "samerole", "replication", a
+# database name, or a comma-separated list thereof. The "all"
+# keyword does not match "replication". Access to replication
+# must be enabled in a separate record (see example below).
+#
+# USER can be "all", a user name, a group name prefixed with "+", or a
+# comma-separated list thereof.  In both the DATABASE and USER fields
+# you can also write a file name prefixed with "@" to include names
+# from a separate file.
+#
+# ADDRESS specifies the set of hosts the record matches.  It can be a
+# host name, or it is made up of an IP address and a CIDR mask that is
+# an integer (between 0 and 32 (IPv4) or 128 (IPv6) inclusive) that
+# specifies the number of significant bits in the mask.  A host name
+# that starts with a dot (.) matches a suffix of the actual host name.
+# Alternatively, you can write an IP address and netmask in separate
+# columns to specify the set of hosts.  Instead of a CIDR-address, you
+# can write "samehost" to match any of the server's own IP addresses,
+# or "samenet" to match any address in any subnet that the server is
+# directly connected to.
+#
+# METHOD can be "trust", "reject", "md5", "password", "scram-sha-256",
+# "gss", "sspi", "ident", "peer", "pam", "ldap", "radius" or "cert".
+# Note that "password" sends passwords in clear text; "md5" or
+# "scram-sha-256" are preferred since they send encrypted passwords.
+#
+# OPTIONS are a set of options for the authentication in the format
+# NAME=VALUE.  The available options depend on the different
+# authentication methods -- refer to the "Client Authentication"
+# section in the documentation for a list of which options are
+# available for which authentication methods.
+#
+# Database and user names containing spaces, commas, quotes and other
+# special characters must be quoted.  Quoting one of the keywords
+# "all", "sameuser", "samerole" or "replication" makes the name lose
+# its special character, and just match a database or username with
+# that name.
+#
+# This file is read on server startup and when the server receives a
+# SIGHUP signal.  If you edit the file on a running system, you have to
+# SIGHUP the server for the changes to take effect, run "pg_ctl reload",
+# or execute "SELECT pg_reload_conf()".
+#
+# Put your actual configuration here
+# ----------------------------------
+#
+# If you want to allow non-local connections, you need to add more
+# "host" records.  In that case you will also need to make PostgreSQL
+# listen on a non-local interface via the listen_addresses
+# configuration parameter, or via the -i or -h command line switches.
+
+
+
+
+# DO NOT DISABLE!
+# If you change this first entry you will need to make sure that the
+# database superuser can access the database using some other method.
+# Noninteractive access to all databases is required during automatic
+# maintenance (custom daily cronjobs, replication, and similar tasks).
+#
+# Database administrative login by Unix domain socket
+local   all             postgres                                peer
+local   all             discourse                               trust
+
+# TYPE  DATABASE        USER            ADDRESS                 METHOD
+
+# "local" is for Unix domain socket connections only
+local   all             all                                     peer
+# IPv4 local connections:
+host all all 0.0.0.0/0 md5
+# IPv6 local connections:
+host all all ::/0 md5
+# Allow replication connections from localhost, by a user with the
+# replication privilege.
+local   replication     all                                     peer
+host    replication     all             127.0.0.1/32            md5
+host    replication     all             ::1/128                 md5


### PR DESCRIPTION
Basic docker env using docker-compose to run keycloak and discourse together.

**Possible improvements:**
Do not require a to mount a `pg_hba.conf` and modify the `discourse/config/database.yml` file, otherwise `rake db:migrate` tries to log in to postgres as root in peer auth mode as it doesnt work.